### PR TITLE
feat: Add Jupyter Notebook for training

### DIFF
--- a/Brain_Tumor_Classification.ipynb
+++ b/Brain_Tumor_Classification.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Brain Tumor Classification using a Fine-Tuned VGG16 Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how to build and train a deep learning model to classify brain tumors from MRI images. We will use a pre-trained VGG16 model and fine-tune it on the Brain Tumor Classification (MRI) dataset from Kaggle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Set Up the Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install tensorflow opencv-python matplotlib kaggle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Download the Dataset from Kaggle\n",
+    "\n",
+    "To use the Kaggle API, you need to have a `kaggle.json` file in your `~/.kaggle/` directory. This file contains your Kaggle username and API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['KAGGLE_USERNAME'] = 'your_kaggle_username'  # Replace with your Kaggle username\n",
+    "os.environ['KAGGLE_KEY'] = 'your_kaggle_api_key'  # Replace with your Kaggle API key\n",
+    "\n",
+    "!kaggle datasets download -d sartajbhuvaji/brain-tumor-classification-mri\n",
+    "!unzip brain-tumor-classification-mri.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.keras.preprocessing.image import ImageDataGenerator\n",
+    "from tensorflow.keras.applications import VGG16\n",
+    "from tensorflow.keras.models import Model\n",
+    "from tensorflow.keras.layers import Dense, Flatten, Dropout\n",
+    "from tensorflow.keras.optimizers import Adam\n",
+    "from tensorflow.keras.callbacks import ModelCheckpoint, ReduceLROnPlateau\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Prepare the Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define paths\n",
+    "train_dir = 'Training'\n",
+    "test_dir = 'Testing'\n",
+    "\n",
+    "# Image parameters\n",
+    "img_height, img_width = 224, 224\n",
+    "batch_size = 32\n",
+    "\n",
+    "# Data augmentation and preprocessing for training\n",
+    "train_datagen = ImageDataGenerator(\n",
+    "    rescale=1./255,\n",
+    "    rotation_range=20,\n",
+    "    width_shift_range=0.2,\n",
+    "    height_shift_range=0.2,\n",
+    "    shear_range=0.2,\n",
+    "    zoom_range=0.2,\n",
+    "    horizontal_flip=True,\n",
+    "    fill_mode='nearest'\n",
+    ")\n",
+    "\n",
+    "# Only rescaling for testing\n",
+    "test_datagen = ImageDataGenerator(rescale=1./255)\n",
+    "\n",
+    "# Load and prepare training data\n",
+    "train_generator = train_datagen.flow_from_directory(\n",
+    "    train_dir,\n",
+    "    target_size=(img_height, img_width),\n",
+    "    batch_size=batch_size,\n",
+    "    class_mode='categorical'\n",
+    ")\n",
+    "\n",
+    "# Load and prepare testing data\n",
+    "test_generator = test_datagen.flow_from_directory(\n",
+    "    test_dir,\n",
+    "    target_size=(img_height, img_width),\n",
+    "    batch_size=batch_size,\n",
+    "    class_mode='categorical',\n",
+    "    shuffle=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Build and Train the Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the VGG16 model with pre-trained weights\n",
+    "base_model = VGG16(weights='imagenet', include_top=False, input_shape=(img_height, img_width, 3))\n",
+    "\n",
+    "# Freeze the convolutional layers\n",
+    "for layer in base_model.layers:\n",
+    "    layer.trainable = False\n",
+    "\n",
+    "# Add custom layers for classification\n",
+    "x = Flatten()(base_model.output)\n",
+    "x = Dense(512, activation='relu')(x)\n",
+    "x = Dropout(0.5)(x)\n",
+    "predictions = Dense(4, activation='softmax')(x)\n",
+    "\n",
+    "# Create the final model\n",
+    "model = Model(inputs=base_model.input, outputs=predictions)\n",
+    "\n",
+    "# Compile the model\n",
+    "model.compile(\n",
+    "    optimizer=Adam(lr=1e-4),\n",
+    "    loss='categorical_crossentropy',\n",
+    "    metrics=['accuracy']\n",
+    ")\n",
+    "\n",
+    "# Print model summary\n",
+    "model.summary()\n",
+    "\n",
+    "# Callbacks\n",
+    "checkpoint = ModelCheckpoint('brain_tumor_model.h5', monitor='val_accuracy', save_best_only=True, mode='max')\n",
+    "reduce_lr = ReduceLROnPlateau(monitor='val_loss', factor=0.2, patience=5, min_lr=1e-6, mode='min')\n",
+    "\n",
+    "# Train the model\n",
+    "epochs = 20\n",
+    "history = model.fit(\n",
+    "    train_generator,\n",
+    "    steps_per_epoch=train_generator.samples // batch_size,\n",
+    "    epochs=epochs,\n",
+    "    validation_data=test_generator,\n",
+    "    validation_steps=test_generator.samples // batch_size,\n",
+    "    callbacks=[checkpoint, reduce_lr]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Evaluate the Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate the model\n",
+    "test_loss, test_acc = model.evaluate(test_generator)\n",
+    "print(f\"Test accuracy: {test_acc:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Plot Training Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acc = history.history['accuracy']\n",
+    "val_acc = history.history['val_accuracy']\n",
+    "loss = history.history['loss']\n",
+    "val_loss = history.history['val_loss']\n",
+    "\n",
+    "epochs_range = range(epochs)\n",
+    "\n",
+    "plt.figure(figsize=(12, 4))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.plot(epochs_range, acc, label='Training Accuracy')\n",
+    "plt.plot(epochs_range, val_acc, label='Validation Accuracy')\n",
+    "plt.title('Training and Validation Accuracy')\n",
+    "plt.legend()\n",
+    "\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.plot(epochs_range, loss, label='Training Loss')\n",
+    "plt.plot(epochs_range, val_loss, label='Validation Loss')\n",
+    "plt.title('Training and Validation Loss')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This commit adds a new Jupyter Notebook that provides a complete workflow for training the brain tumor classification model.

The notebook includes the following steps:
- Downloading the dataset from Kaggle.
- Preprocessing the data.
- Building and training the model using VGG16.
- Evaluating the model and visualizing the results.